### PR TITLE
Feature/additional relation type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ if (class_exists('\\Basilicom\\PathFormatterBundle\\BasilicomPathFormatterBundle
     
 
 ## Advanced configuration
+### Contextual pattern overwrites 
 It is possible to configure a context-based pattern, so that a dataObject in a relation-field of a specific class will be formatted differently.  
 
 **Example:**
-```
+```yaml
 # app/config/config.yml
 basilicom_path_formatter:
   pattern: 
@@ -81,6 +82,19 @@ basilicom_path_formatter:
 ```
 
 While the product will be formatted like ``Sneakers 19.99EUR`` in all relation-fields, the ProductList-Class will show them like ``#13 - Sneakers`` or ``#13 - Sneakers (premium-only!)``, based on the product class.
+
+### Formatting documents and assets
+```yaml
+basilicom_path_formatter:
+  pattern:
+    Pimcore\Model\Asset: "{id} {key}"
+    Pimcore\Model\Document: "{id} {key}"
+
+    Pimcore\Model\DataObject\Car::files:
+      patternOverwrites:
+        Pimcore\Model\Asset: "{key}"
+        Pimcore\Model\Document: "{key}"
+```
 
 ## Additional features
 

--- a/src/DependencyInjection/BasilicomPathFormatter.php
+++ b/src/DependencyInjection/BasilicomPathFormatter.php
@@ -35,12 +35,16 @@ class BasilicomPathFormatter implements PathFormatterInterface
         if (!empty($this->patternConfiguration)) {
             foreach ($targets as $key => $item) {
                 if ($item['type'] === 'object') {
-                    $target = $this->pimcoreAdapter->getConcreteById($item['id']);
+                    $targetElement = $this->pimcoreAdapter->getConcreteById($item['id']);
                 } elseif ($item['type'] === 'asset') {
-                    $target = $this->pimcoreAdapter->getAssetById($item['id']);
+                    $targetElement = $this->pimcoreAdapter->getAssetById($item['id']);
                 } elseif ($item['type'] === 'document') {
-                    $target = $this->pimcoreAdapter->getDocumentById($item['id']);
+                    $targetElement = $this->pimcoreAdapter->getDocumentById($item['id']);
                 } else {
+                    continue;
+                }
+
+                if (!$targetElement) {
                     continue;
                 }
 
@@ -51,13 +55,13 @@ class BasilicomPathFormatter implements PathFormatterInterface
                             $patternConfig[ConfigDefinition::PATTERN_OVERWRITES],
                             $params['context'],
                             $source,
-                            $target
+                            $targetElement
                         );
                     } else {
                         $formattedPath = $this->getFormattedPath(
                             $patternKey,
                             $patternConfig[ConfigDefinition::PATTERN],
-                            $target
+                            $targetElement
                         );
                     }
 

--- a/src/DependencyInjection/PimcoreAdapter.php
+++ b/src/DependencyInjection/PimcoreAdapter.php
@@ -2,6 +2,8 @@
 
 namespace Basilicom\PathFormatterBundle\DependencyInjection;
 
+use Pimcore\Model\Asset;
+use Pimcore\Model\Document;
 use Pimcore\Model\DataObject\Concrete;
 
 class PimcoreAdapter
@@ -9,5 +11,15 @@ class PimcoreAdapter
     public function getConcreteById(int $id): ?Concrete
     {
         return Concrete::getById($id);
+    }
+
+    public function getAssetById(int $id): ?Asset
+    {
+        return Asset::getById($id);
+    }
+
+    public function getDocumentById(int $id): ?Document
+    {
+        return Document::getById($id);
     }
 }


### PR DESCRIPTION
Allowing to configure patterns for Assets like
```
basilicom_path_formatter:
  pattern:
    Pimcore\Model\Asset: "{id} {key}"
    Pimcore\Model\Document: "{id} {key}"
    Pimcore\Model\DataObject\Passenger: "{id} {name}"

    Pimcore\Model\DataObject\Car::files:
      patternOverwrites:
        Pimcore\Model\DataObject\Passenger: "{name}"
        Pimcore\Model\Asset: "#{id} {key}"
        Pimcore\Model\Document: "#{id} {key}"
```